### PR TITLE
Add email signup buttons

### DIFF
--- a/assets/css/_core/_base.scss
+++ b/assets/css/_core/_base.scss
@@ -49,6 +49,7 @@ body {
 @import "../_partial/details";
 @import "../_partial/fixed-button";
 @import "../_partial/cookieconsent";
+@import "../_partial/button";
 
 img {
   @include object-fit(contain);

--- a/assets/css/_page/_home.scss
+++ b/assets/css/_page/_home.scss
@@ -63,6 +63,12 @@
         color: $global-font-secondary-color-dark;
       }
     }
+
+    .home-subscription {
+      margin-top: 1rem;
+      font-size: 16px;
+      font-weight: bold;
+    }
   }
 }
 

--- a/assets/css/_partial/_button.scss
+++ b/assets/css/_partial/_button.scss
@@ -3,7 +3,7 @@ $tcolor: whitesmoke;
 a.button {
   border-radius: 8px;
   border: none;
-  padding: 12px 32px;
+  padding: .8rem 1.5rem;
   display: inline-block;
   background-color: #ae3030;
   color: $tcolor;

--- a/assets/css/_partial/_button.scss
+++ b/assets/css/_partial/_button.scss
@@ -1,0 +1,16 @@
+$tcolor: whitesmoke;
+
+a.button {
+  border-radius: 8px;
+  border: none;
+  padding: 12px 32px;
+  display: inline-block;
+  background-color: #ae3030;
+  color: $tcolor;
+  text-align: center;
+  text-decoration: none;
+
+  &:hover {
+    color: $tcolor;
+  }
+}

--- a/assets/css/_partial/_footer.scss
+++ b/assets/css/_partial/_footer.scss
@@ -14,6 +14,12 @@ footer {
       .icp-br {
         display: none;
       }
+
+      .subscription {
+        font-weight: bold;
+        padding: .5rem 1.2rem;
+        margin-bottom: .7rem;
+      }
     }
   }
 

--- a/assets/css/_partial/_header.scss
+++ b/assets/css/_partial/_header.scss
@@ -188,6 +188,12 @@ header {
         &.search {
           margin: 0 -.5rem 0 0;
         }
+
+        &.subscription {
+          display: inline;
+          padding: 0.5rem 1rem 0.5rem 1rem;
+          font-weight: bold;
+        }
       }
 
       a.active {
@@ -313,6 +319,12 @@ header {
       .menu-item {
         display: block;
         line-height: 2.5rem;
+
+        &.subscription {
+          padding-top: 0.3rem;
+          padding-bottom: 0.3rem;
+          font-weight: bold;
+        }
       }
 
       &.active {

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,6 +7,14 @@
                     {{- safeHTML . -}}
                 </div>
             {{- end -}}
+            {{- /* Subscription */ -}}
+            {{- with .Site.Params.Subscription -}}
+                <div class="footer-line">
+                    <a class="button subscription" href="{{.link}}" rel="nofollow" target="_blank" title="Subscribe">
+                        {{.text}}
+                    </a>
+                </div>
+            {{- end -}}
 
             {{- /* Hugo and LoveIt */ -}}
             {{- if ne .Site.Params.footer.hugo false -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -36,6 +36,11 @@
                         {{- .Pre | safeHTML }} {{ .Name }} {{ .Post | safeHTML -}}
                     </a>
                 {{- end -}}
+                {{- with .Site.Params.subscription -}}
+                    <a class="button menu-item subscription" href="{{.link}}" rel="nofollow" target="_blank" title="Subscribe">
+                        {{.text}}
+                    </a>
+                {{- end -}}
                 {{- if .Site.Menus.main -}}
                     <span class="menu-item delimiter"></span>
                 {{- end -}}
@@ -144,6 +149,11 @@
                 {{- end -}}
                 <a class="menu-item" href="{{ $url }}" title="{{ .Title }}"{{ if (urls.Parse $url).Host }} rel="noopener noreffer" target="_blank"{{ end }}>
                     {{- .Pre | safeHTML }}{{ .Name }}{{ .Post | safeHTML -}}
+                </a>
+            {{- end -}}
+            {{- with .Site.Params.subscription -}}
+                <a class="button menu-item subscription" href="{{.link}}" rel="nofollow" target="_blank" title="Subscribe">
+                    {{.text}}
                 </a>
             {{- end -}}
             <a href="javascript:void(0);" class="menu-item theme-switch" title="{{ T "switchTheme" }}">

--- a/layouts/partials/home/profile.html
+++ b/layouts/partials/home/profile.html
@@ -92,4 +92,8 @@
             {{- . | safeHTML -}}
         </h3>
     {{- end -}}
+
+    {{- with .Site.Params.subscription -}}
+        <a class="button home-subscription" href="{{.link}}" rel="nofollow" target="_blank">{{.text}}</a>
+    {{- end -}}
 </div>


### PR DESCRIPTION
The new site subscription parameter generates buttons that may redirect to a signup form.

## Add

* New site parameter to set an email subscription.

```toml
  [params.subscription]
    # URL of the signup form.
    link = "https://example.com"
    # Button text.
    text = "Subscribe now"
```

* HTML buttons for email subscription.
  * Top right
  * Below the home title
  * Above the copyrights